### PR TITLE
config to use cloud.drone.io for CI 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,16 @@
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: ocaml/opam2:4.07
+  commands:
+  - sudo apt-get update && sudo apt-get -y install libgmp-dev m4
+  - sudo chown -R opam .
+  - export ITER=1
+  - export OPAM_DISABLE_SANDBOXING=true
+  - make ocaml-versions/4.07.1.bench


### PR DESCRIPTION
Basic CI setup that gets all the dependencies setup and does:
`make ocaml-versions/4.07.1.bench`
fails when this returns a non-zero exit (e.g. a benchmark run failing)