### PR TITLE
Remove Gc.set from benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ PACKAGES = \
   js_of_ocaml-compiler uuidm react ocplib-endian nbcodec \
   checkseum decompress
 
-ifeq ($(BENCH_TARGET),multibench)
+# want to handle 'multibench' and 'benchmarks/multicore-lockfree/multibench' as target
+ifeq ($(findstring multibench,$(BENCH_TARGET)),multibench)
 	PACKAGES += lockfree kcas
 endif
 

--- a/benchmarks/benchmarksgame/binarytrees5.ml
+++ b/benchmarks/benchmarksgame/binarytrees5.ml
@@ -21,7 +21,8 @@ let max_depth = (let n = try int_of_string(Array.get Sys.argv 1) with _ -> 10 in
 let stretch_depth = max_depth + 1
 
 let () =
-  (* Gc.set { (Gc.get()) with Gc.minor_heap_size = 1024 * 1024; max_overhead = -1; }; *)
+  (* GC param suggestion:
+    Gc.set { (Gc.get()) with Gc.minor_heap_size = 1024 * 1024; max_overhead = -1; }; *)
   let c = check (make stretch_depth) in
   Printf.printf "stretch tree of depth %i\t check: %i\n" stretch_depth c
 

--- a/benchmarks/benchmarksgame/knucleotide.ml
+++ b/benchmarks/benchmarksgame/knucleotide.ml
@@ -79,7 +79,8 @@ let dna_three =
    done with End_of_file -> ());
   Buffer.to_bytes buf
 
-let () = Gc.set { (Gc.get()) with Gc.minor_heap_size = 1024 * 2048 }
+(* GC param suggestion:
+ let () = Gc.set { (Gc.get()) with Gc.minor_heap_size = 1024 * 2048 } *)
 
 let () =
   List.iter (fun i -> write_frequencies i dna_three) [1; 2];

--- a/benchmarks/numerical-analysis/fft.ml
+++ b/benchmarks/numerical-analysis/fft.ml
@@ -54,10 +54,10 @@ let ifft x =
   let normalize z = { re = c *. z.re; im = ~-. c *. z.im } in
   fft (Array.map normalize x)
 
-let c = Gc.get ()
+(* GC param suggestion:
 let () = Gc.set
-    { c with Gc.minor_heap_size = 2000000;
-             Gc.space_overhead = 80 * 20 }
+    { (Gc.get()) with Gc.minor_heap_size = 2000000;
+             Gc.space_overhead = 80 * 20 } *)
 
 let gather t =
   t.Unix.tms_utime +. t.Unix.tms_stime +. t.Unix.tms_cutime +. t.Unix.tms_cstime


### PR DESCRIPTION

This branch:
 - removes Gc.set done inline in some tests. 
 - fixes up the makefile to handle doing multibench on a given benchmark directory